### PR TITLE
No more delay when closing an accordion item

### DIFF
--- a/src/bellows.js
+++ b/src/bellows.js
@@ -188,7 +188,7 @@ Mobify.UI.Bellows = (function($, Utils) {
             // toggle active class on close only if there is no transition support
             if(!Utils.events.transitionend) $item.removeClass(activeClass);
             // set max-height to 0 upon close
-            $item.find('.' + contentClass).css('max-height', 0);
+            $item.find('.' + contentClass).css('max-height', '0px');
         }
         
         function open($item) {


### PR DESCRIPTION
A workaround for older Zepto that doesn't handle zero properly. With
older Zepto, passing 0 (in number) will remove the given css property.
The browser then falls back to the IE hack of max-height:10000px.

For more details on the older Zepto, see this code:
https://github.com/madrobby/zepto/blob/5f4eebd01c398cb076be3e8d692b8d138
cd5a100/src/zepto.js#L450

(Thanks Ted and Jeff for pointing me in the right directions)
