### PR TITLE
Adds support for pointer events

### DIFF
--- a/src/bellows.js
+++ b/src/bellows.js
@@ -6,7 +6,7 @@ Mobify.UI = Mobify.UI || {};
     $.support = $.support || {};
 
     $.extend($.support, {
-        'touch': 'ontouchend' in document
+        'touch': 'ontouchend' in document,
         'pointer': (window.navigator.msPointerEnabled !== undefined)
     });
 


### PR DESCRIPTION
Adds support for pointer events in order to get the slideshow to work on devices that support both mouse and touch (primarily Windows 8).

This has yet to be tested on an actual Windows 8 device. Do not merge until it has been. Also, this is likely a change we want to make for Scootch, Magnifik, and Pikabu as well.
