### PR TITLE
Upgrading to latest plugin factory

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 5.0.0
+  - Upgrading to latest version of plugin factory
   - Adding `destroy` method
   - Removing `event` option in favour of internalizing a namespaced event 
 4.1.2

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "./!(src|dist|lib|templates)"
   ],
   "dependencies": {
-    "plugin": "2.1.0",
+    "plugin": "~3.0.0",
     "mobify-velocity": "1.1.2",
     "requirejs-text": "~2.0.12",
     "requirejs": "~2.1.14"

--- a/tests/unit/plugin.js
+++ b/tests/unit/plugin.js
@@ -120,8 +120,8 @@ define([
                     }
                 });
 
+                $element.bellows('add', items);
                 $element
-                    .bellows('add', items)
                     .find('.bellows__header:eq(3)')
                     .trigger('click');
             });


### PR DESCRIPTION
Updates version of bellows to the version of plugin with the method call fix.

Status: **Opened for visibility**

Reviewers: @Helen-Mobify 

## Changes
- updated version of plugin in bower.json

## How to test-drive this PR
- checkout this branch
- `rm -rf bower_components`
- `bower install`
- `grunt test`